### PR TITLE
CONV-646 support for signed identity

### DIFF
--- a/drift/src/main/java/drift/com/drift/Drift.java
+++ b/drift/src/main/java/drift/com/drift/Drift.java
@@ -40,10 +40,28 @@ public class Drift {
         return _drift;
     }
 
+    public static void registerUser(String userId, String email, String userJwt) {
+        if (!isConnected()) {
+            LoggerHelper.logMessage("LIFECYCLE", "Registering User");
+            DriftManager.getInstance().registerUser(userId, email, userJwt);
+        } else {
+            LoggerHelper.logMessage("LIFECYCLE", "Not Registering User, already connected");
+        }
+    }
+
+    public static void registerUser(String userId) {
+        if (!isConnected()) {
+            LoggerHelper.logMessage("LIFECYCLE", "Registering User");
+            DriftManager.getInstance().registerUser(userId, null, null);
+        } else {
+            LoggerHelper.logMessage("LIFECYCLE", "Not Registering User, already connected");
+        }
+    }
+
     public static void registerUser(String userId, String email) {
         if (!isConnected()) {
             LoggerHelper.logMessage("LIFECYCLE", "Registering User");
-            DriftManager.getInstance().registerUser(userId, email);
+            DriftManager.getInstance().registerUser(userId, email, null);
         } else {
             LoggerHelper.logMessage("LIFECYCLE", "Not Registering User, already connected");
         }

--- a/drift/src/main/java/drift/com/drift/managers/DriftManager.java
+++ b/drift/src/main/java/drift/com/drift/managers/DriftManager.java
@@ -44,7 +44,7 @@ public class DriftManager {
                     LoggerHelper.logMessage(TAG, "Get Embed Success");
 
                     if (registerInformation != null) {
-                        registerUser(registerInformation.userId, registerInformation.email);
+                        registerUser(registerInformation.userId, registerInformation.email, registerInformation.userJwt);
                     }
 
                 }
@@ -52,13 +52,13 @@ public class DriftManager {
         });
     }
 
-    public void registerUser(String userId, final String email) {
+    public void registerUser(String userId, final String email, final String userJwt) {
 
         final Embed embed = Embed.getInstance();
 
         if (embed == null) {
             LoggerHelper.logMessage(TAG, "No Embed, not registering yet");
-            registerInformation = new RegisterInformation(userId, email);
+            registerInformation = new RegisterInformation(userId, email, userJwt);
             return;
         }
 
@@ -70,12 +70,12 @@ public class DriftManager {
 
         ///Post Identify
         loadingUser = true;
-        DriftManagerWrapper.postIdentity(embed.orgId, userId, email, new APICallbackWrapper<IdentifyResponse>() {
+        DriftManagerWrapper.postIdentity(embed.orgId, userId, email, userJwt, new APICallbackWrapper<IdentifyResponse>() {
             @Override
             public void onResponse(IdentifyResponse response) {
                 if ( response != null ) {
                     LoggerHelper.logMessage(TAG, "Identify Complete");
-                    getAuth(embed, response, email);
+                    getAuth(embed, response, email, userJwt);
                 } else {
                     LoggerHelper.logMessage(TAG, "Identify Failed");
                     loadingUser = false;
@@ -84,9 +84,9 @@ public class DriftManager {
         });
     }
 
-    private void getAuth(final Embed embed, IdentifyResponse identifyResponse, String email) {
+    private void getAuth(final Embed embed, IdentifyResponse identifyResponse, String email, String userJwt) {
 
-        DriftManagerWrapper.getAuth(identifyResponse.orgId, identifyResponse.userId, email, embed.configuration.redirectUri, embed.configuration.authClientId, new APICallbackWrapper<Auth>() {
+        DriftManagerWrapper.getAuth(identifyResponse.orgId, identifyResponse.userId, email, userJwt, embed.configuration.redirectUri, embed.configuration.authClientId, new APICallbackWrapper<Auth>() {
             @Override
             public void onResponse(Auth response) {
                 if (response != null) {
@@ -118,12 +118,14 @@ public class DriftManager {
 
     private class RegisterInformation {
 
+        public String userJwt;
         private String userId;
         private String email;
 
-        RegisterInformation(String userId, String email){
+        RegisterInformation(String userId, String email, String userJwt){
             this.email = email;
             this.userId = userId;
+            this.userJwt = userJwt;
         }
 
     }

--- a/drift/src/main/java/drift/com/drift/wrappers/DriftManagerWrapper.java
+++ b/drift/src/main/java/drift/com/drift/wrappers/DriftManagerWrapper.java
@@ -39,12 +39,17 @@ public class DriftManagerWrapper {
     }
 
 
-    public static void postIdentity(int orgId, String userId, String email, final APICallbackWrapper<IdentifyResponse> callback){
+    public static void postIdentity(int orgId, String userId, String email, String userJwt, final APICallbackWrapper<IdentifyResponse> callback){
 
         HashMap<String, Object> jsonPayload = new HashMap<>();
 
         jsonPayload.put("orgId", orgId);
         jsonPayload.put("userId", userId);
+
+        if (userJwt != null) {
+            jsonPayload.put("signedIdentity", userJwt);
+        }
+
 
         HashMap<String, Object> inlineEmailAttributes = new HashMap<>();
         inlineEmailAttributes.put("email", email);
@@ -68,7 +73,7 @@ public class DriftManagerWrapper {
         });
     }
 
-    public static void getAuth(int orgId, String userId, String email, String redirectUri, String clientId, final APICallbackWrapper<Auth> callback){
+    public static void getAuth(int orgId, String userId, String email, String userJwt, String redirectUri, String clientId, final APICallbackWrapper<Auth> callback){
 
         HashMap<String, Object> jsonPayload = new HashMap<>();
 
@@ -79,6 +84,9 @@ public class DriftManagerWrapper {
         jsonPayload.put("redirect_uri", redirectUri);
         jsonPayload.put("client_id", clientId);
 
+        if (userJwt != null) {
+            jsonPayload.put("userJwt", userJwt);
+        }
 
         APIManager.getCustomerClient().getAuth(jsonPayload).enqueue(new Callback<Auth>() {
             @Override


### PR DESCRIPTION
Ability to pass user jwt that contains user id so we can validate user identity. 

New public api now has userJwt optional argument: 
 -  `Drift.registerUser("123748");`
 -  `Drift.registerUser("123748", "sample@drift.com");`
-   `Drift.registerUser("123748", "sample@drift.com", "user jwt");`

To get userJwt org should enable signed identities and obtain secret from Drift that can be used to generate token.